### PR TITLE
Change CurrentWeather model to match new open weather json

### DIFF
--- a/weather_command/models/weather.py
+++ b/weather_command/models/weather.py
@@ -42,8 +42,6 @@ class Main(CamelBase):
 
 
 class Sys(CamelBase):
-    type: int
-    id: int
     country: str
     sunrise: datetime
     sunset: datetime


### PR DESCRIPTION
Open weather changed the json return values for the current weather which broke getting the current information. This update fixes that.