### PR TITLE
Fix install error when uvloop not present

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ A command line weather app
 
 Installation with [pipx](https://github.com/pypa/pipx) is recommended.
 
+If you are running on a non-Windows OS you can install with uvloop for more speed.
+
+```sh
+pipx install "weather-command[uvloop]"
+```
+
+uvloop is currently not supported on Windows on this platform install without uvloop.
+
 ```sh
 pipx install weather-command
 ```
@@ -19,6 +27,10 @@ pipx install weather-command
 Alternatively Weather Command can be installed with pip.
 
 ```sh
+# Non Windows
+pip install weather-command[uvloop]
+
+# Windows
 pip install weather-command
 ```
 

--- a/weather_command/main.py
+++ b/weather_command/main.py
@@ -19,7 +19,10 @@ def _is_uvloop_platform() -> bool:
 
 
 if _is_uvloop_platform():
-    import uvloop
+    try:
+        import uvloop
+    except ImportError:
+        pass
 
 __version__ = "3.2.1"
 
@@ -85,7 +88,10 @@ def cli(
     """Run in CLI mode."""
 
     if _is_uvloop_platform():
-        uvloop.install()
+        try:
+            uvloop.install()
+        except NameError:
+            pass
 
     if clear_cache:
         cache = Cache()


### PR DESCRIPTION
Poetry is not properly creating the `setup.py` file for system specific installs and creating it as an extra. This update fixes errors that occur from this.