### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ will get the current forecast, `wed` will get the daily forecast and `weh` will 
 
 ![Hourl weather temp only](./assets/hourly_temp_only.png)
 
+## Settings
+The weather-command now has the ability to save settings to default certain flags. The list of possible settings can be seen with:
+
+```sh
+weather-command settings --help
+```
 ## Contributing
 
 Contributions to this project are welcome. If you are interesting in contributing please see our [contributing guide](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ will get the current forecast, `wed` will get the daily forecast and `weh` will 
 ![Hourl weather temp only](./assets/hourly_temp_only.png)
 
 ## Settings
-The weather-command now has the ability to save settings to default certain flags. The list of possible settings can be seen with:
+weather now has the ability to save settings to default certain flags. The list of possible settings can be seen with:
 
 ```sh
-weather-command settings --help
+weather settings --help
 ```
 ## Contributing
 


### PR DESCRIPTION
Added information to the readme about the ability to save settings to default certain flags in weather-command. Users can now see the list of possible settings by running "weather-command settings --help". This update will help users better understand how to customize and personalize their experience with the command line weather app.