### PR TITLE
Change utcnow to now with time zone

### DIFF
--- a/tests/assets/cache.json
+++ b/tests/assets/cache.json
@@ -7,7 +7,7 @@
     },
     "currentWeather": {
       "cache_duration_minutes": 15,
-      "date_time_saved": "2021-12-22T01:36:38.212266",
+      "date_time_saved": "2021-12-22T01:36:38.212266+00:00",
       "current_weather": {
         "coord": { "lon": -79.8133, "lat": 36.1581 },
         "weather": [
@@ -48,7 +48,7 @@
     },
     "oneCallWeather": {
       "cache_duration_minutes": 15,
-      "date_time_saved": "2021-12-22T01:36:52.676059",
+      "date_time_saved": "2021-12-22T01:36:52.676059+00:00",
       "one_call_weather": {
         "lat": 36.1581,
         "lon": -79.8133,
@@ -1692,7 +1692,7 @@
     },
     "currentWeather": {
       "cache_duration_minutes": 15,
-      "date_time_saved": "2021-12-22T01:36:38.212266",
+      "date_time_saved": "2021-12-22T01:36:38.212266+00:00",
       "current_weather": {
         "coord": { "lon": -79.8133, "lat": 36.1581 },
         "weather": [
@@ -1733,7 +1733,7 @@
     },
     "oneCallWeather": {
       "cache_duration_minutes": 15,
-      "date_time_saved": "2021-12-22T01:36:52.676059",
+      "date_time_saved": "2021-12-22T01:36:52.676059+00:00",
       "one_call_weather": {
         "lat": 36.1581,
         "lon": -79.8133,

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from os import getenv
 from unittest.mock import Mock, patch
 
@@ -77,7 +77,7 @@ async def test_current_weather_no_cache_hit(
 @pytest.mark.usefixtures("mock_cache_dir_with_file")
 @patch("weather_command._cache.datetime")
 async def test_current_weather_cache_hit(mock_dt, how, city_zip, temp_only, pager, capfd):
-    mock_dt.utcnow = Mock(return_value=datetime(2021, 12, 22, 1, 36, 38))
+    mock_dt.now = Mock(return_value=datetime(2021, 12, 22, 1, 36, 38, tzinfo=timezone.utc))
     await _builder.show_current(how, city_zip, temp_only=temp_only, pager=pager)
     out, _ = capfd.readouterr()
     assert "Greensboro" in out
@@ -136,7 +136,7 @@ async def test_show_daily_no_cache_hit(
 @pytest.mark.usefixtures("mock_cache_dir_with_file")
 @patch("weather_command._cache.datetime")
 async def test_show_daily_cache_hit(mock_dt, temp_only, pager, capfd):
-    mock_dt.utcnow = Mock(return_value=datetime(2021, 12, 22, 1, 36, 38))
+    mock_dt.now = Mock(return_value=datetime(2021, 12, 22, 1, 36, 38, tzinfo=timezone.utc))
     await _builder.show_daily("zip", "27455", temp_only=temp_only, pager=pager)
     out, _ = capfd.readouterr()
     assert "Greensboro" in out
@@ -215,7 +215,7 @@ async def test_show_hourly_no_cache_hit(
 @pytest.mark.usefixtures("mock_cache_dir_with_file")
 @patch("weather_command._cache.datetime")
 async def test_show_hourly_cache_hit(mock_dt, temp_only, pager, capfd):
-    mock_dt.utcnow = Mock(return_value=datetime(2021, 12, 22, 1, 36, 38))
+    mock_dt.now = Mock(return_value=datetime(2021, 12, 22, 1, 36, 38, tzinfo=timezone.utc))
     await _builder.show_hourly("zip", "27455", temp_only=temp_only, pager=pager)
     out, _ = capfd.readouterr()
     assert "Greensboro" in out

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,6 +1,6 @@
 import json
 import os
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -153,7 +153,7 @@ def test_add_cache_hit(
     use_one_call_weather,
     cache_with_file,
 ):
-    mock_dt.utcnow = Mock(return_value=datetime(2021, 12, 22, 1, 36, 38))
+    mock_dt.now = Mock(return_value=datetime(2021, 12, 22, 1, 36, 38, tzinfo=timezone.utc))
     if use_location:
         location = mock_location
     else:
@@ -202,7 +202,7 @@ def test_clear(cache):
 
 @patch("weather_command._cache.datetime")
 def test_get(mock_dt, cache_with_file):
-    mock_dt.utcnow = Mock(return_value=datetime(2021, 12, 22, 1, 36, 38))
+    mock_dt.now = Mock(return_value=datetime(2021, 12, 22, 1, 36, 38, tzinfo=timezone.utc))
     cache_values = cache_with_file.get(
         "https://nominatim.openstreetmap.org/search?format=json&limit=1&postalcode=27455"
     )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -86,7 +86,7 @@ def test_main_cache_hit(
     test_runner,
     cache_with_file,
 ):
-    mock_dt.utcnow = Mock(return_value=datetime(2021, 12, 22, 1, 36, 38))
+    mock_dt.now = Mock(return_value=datetime(2021, 12, 22, 1, 36, 38, tzinfo=timezone.utc))
     location = mock_location
     current_weather = mock_current_weather
     one_call_weather = mock_one_call_weather

--- a/weather_command/_cache.py
+++ b/weather_command/_cache.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import os
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from json import JSONEncoder
 from pathlib import Path
 from typing import Any, Optional
@@ -75,14 +75,14 @@ class Cache:
             location_cache = location.dict() if location else None
             current_weather_cache = (
                 CurrentWeatherCache(
-                    date_time_saved=datetime.utcnow(), current_weather=current_weather
+                    date_time_saved=datetime.now(tz=timezone.utc), current_weather=current_weather
                 ).dict()
                 if current_weather
                 else None
             )
             one_call_weather_cache = (
                 OneCallWeatherCache(
-                    date_time_saved=datetime.utcnow(), one_call_weather=one_call_weather
+                    date_time_saved=datetime.now(tz=timezone.utc), one_call_weather=one_call_weather
                 ).dict()
                 if one_call_weather
                 else None
@@ -135,12 +135,12 @@ class Cache:
 
         cache = self._cache[cache_key.lower()]
         if cache.current_weather:
-            time_diff = datetime.utcnow() - cache.current_weather.date_time_saved
+            time_diff = datetime.now(tz=timezone.utc) - cache.current_weather.date_time_saved
             if (time_diff.total_seconds() / 60) > cache.current_weather.cache_duration_minutes:
                 cache.current_weather = None
 
         if cache.one_call_weather:
-            time_diff = datetime.utcnow() - cache.one_call_weather.date_time_saved
+            time_diff = datetime.now(tz=timezone.utc) - cache.one_call_weather.date_time_saved
             if (time_diff.total_seconds() / 60) > cache.one_call_weather.cache_duration_minutes:
                 cache.one_call_weather = None
 


### PR DESCRIPTION
`utcnow` is being [depreciated](https://github.com/python/cpython/issues/103857) in Python 3.12